### PR TITLE
perf: optimize logo image loading with priority

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -18,6 +18,7 @@ const { siteLogo, navLinks } = Astro.props;
       width="45"
       height="45"
       alt="website logo"
+      loading="eager"
     />
   </a>
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -18,7 +18,7 @@ const { siteLogo, navLinks } = Astro.props;
       width="45"
       height="45"
       alt="website logo"
-      loading="eager"
+      priority
     />
   </a>
 


### PR DESCRIPTION
remove toolbar notice (unless this is intentional!) 

<img width="468" height="229" alt="Screenshot 2026-05-18 at 2 02 23 PM" src="https://github.com/user-attachments/assets/af1539a2-72eb-4802-baa8-21c0350b8e03" />
